### PR TITLE
Externalize API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,14 @@ Gestion-stock est une petite démonstration d'application mobile réalisée avec
    ```bash
    npm run dev
    ```
+
 3. Scannez le QR code affiché ou démarrez un émulateur pour ouvrir l'application.
+
+## Configuration de l'API
+
+L'application communique avec un serveur distant pour la connexion et la
+synchronisation. L'URL de base peut être modifiée dans le fichier
+`app.config.ts` en changeant la valeur de `API_BASE_URL`.
 
 ## Lancer l'application
 

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = process.env.API_BASE_URL || 'https://example.com/api';

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { API_BASE_URL } from '@/app.config';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 import { Product, Alert, AppSettings, ToastMessage } from '@/types';
@@ -156,7 +157,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
 
   const fetchRemoteData = async (token: string) => {
     try {
-      const res = await fetch('https://example.com/api/data', {
+      const res = await fetch(`${API_BASE_URL}/data`, {
         headers: { Authorization: `Bearer ${token}` }
       });
       if (!res.ok) return;
@@ -172,7 +173,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
   const syncToCloud = async () => {
     if (!authToken) return;
     try {
-      await fetch('https://example.com/api/sync', {
+      await fetch(`${API_BASE_URL}/sync`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -192,7 +193,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
     }
 
     try {
-      const res = await fetch('https://example.com/api/login', {
+      const res = await fetch(`${API_BASE_URL}/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password })


### PR DESCRIPTION
## Summary
- centralize API base URL in `app.config.ts`
- use `API_BASE_URL` in `AppContext`
- document API base URL configuration

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e8f7fef883288834feb781eb197a