### PR TITLE
Add AppContext tests and Jest setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -37,3 +37,14 @@ Depuis le tableau de bord (premier onglet), appuyez sur **"🎯 Tester l'App"**.
 Cette version stocke toutes les données uniquement en local via `AsyncStorage`. Aucune synchronisation ou sauvegarde distante n'est effectuée et les informations seront perdues si vous réinstallez l'application.
 
 Certaines fonctionnalités comme l'import/export complet ou la synchronisation cloud sont présentées dans l'interface mais ne sont pas implémentées dans cette démo.
+
+## Tests automatisés
+
+Une petite suite de tests Jest vérifie le fonctionnement du contexte `AppContext`.
+Pour l'exécuter après avoir installé les dépendances :
+
+```bash
+npm test
+```
+
+Jest lance alors tous les tests présents dans le dossier `__tests__`.

--- a/__tests__/AppContext.test.tsx
+++ b/__tests__/AppContext.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { AppProvider, useApp } from '@/contexts/AppContext';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(() => Promise.resolve(null)),
+  setItem: jest.fn(() => Promise.resolve()),
+  removeItem: jest.fn(() => Promise.resolve()),
+  clear: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve(null)),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+  deleteItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  global.fetch = jest.fn((url) => {
+    if (typeof url === 'string' && url.includes('/api/login')) {
+      return Promise.resolve({ ok: true, json: async () => ({ token: 'token' }) });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  });
+});
+
+describe('AppContext', () => {
+  it('authenticates user on login', async () => {
+    const { result } = renderHook(() => useApp(), { wrapper: AppProvider });
+
+    await act(async () => {
+      await result.current.login('user@example.com', 'pass');
+    });
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.userEmail).toBe('user@example.com');
+  });
+
+  it('adds products and suppliers', () => {
+    const { result } = renderHook(() => useApp(), { wrapper: AppProvider });
+
+    const newProducts = [
+      {
+        id: 1,
+        supplier: 'Demo',
+        ean: '1',
+        name: 'Prod 1',
+        currentStock: 0,
+        alertThreshold: 5,
+        movements: [],
+        stockInitialized: false,
+        createdAt: new Date().toISOString(),
+      },
+      {
+        id: 2,
+        supplier: 'Other',
+        ean: '2',
+        name: 'Prod 2',
+        currentStock: 0,
+        alertThreshold: 5,
+        movements: [],
+        stockInitialized: false,
+        createdAt: new Date().toISOString(),
+      },
+    ];
+
+    act(() => {
+      result.current.addProducts(newProducts);
+    });
+
+    expect(result.current.products).toHaveLength(2);
+    expect(result.current.suppliers).toEqual(expect.arrayContaining(['Demo', 'Other']));
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "EXPO_NO_TELEMETRY=1 expo start",
     "build:web": "expo export --platform web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -48,7 +49,11 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@expo/cli": "^0.22.0",
+    "@types/jest": "^29.5.11",
     "@types/react": "~19.0.10",
+    "@testing-library/react": "^16.3.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "typescript": "~5.8.3"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest configuration and test script
- write tests for AppContext authentication and product addition
- document test usage in README
- create .gitignore to avoid committing node_modules

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e8fa9b5083288bfa211e4354052d