### PR TITLE
Fix README to remove outdated guest login

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ synchronisation. L'URL de base peut être modifiée dans le fichier
 
 ## Lancer l'application
 
-À la première ouverture, une page de connexion s'affiche. Pour la démo, entrez n'importe quel email et mot de passe ou utilisez le bouton **"Essai rapide"** pour accéder directement à l'interface.
+À la première ouverture, une page de connexion s'affiche. Pour la démo, entrez simplement un email et un mot de passe pour accéder à l'interface.
 
 ### Charger les données d'exemple
 


### PR DESCRIPTION
## Summary
- update login instructions in README

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2bfd9b20832885b58c8adae71582