### PR TITLE
Add .gitignore with common patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.expo/
+dist/
+*.log
+# Misc
+.DS_Store
+.env
+


### PR DESCRIPTION
## Summary
- add a root `.gitignore` covering node_modules, `.expo`, build artifacts and logs

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2bff78bc83289e67512855bbe2da